### PR TITLE
Replace log4j with slf4j

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -59,9 +59,9 @@
             <version>1.4.0</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.32</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
         <dependency>
@@ -69,10 +69,28 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.14.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <gpudb-api.version>7.1.4.0</gpudb-api.version>
     </properties>

--- a/api/src/main/java/com/gpudb/GPUdbLogger.java
+++ b/api/src/main/java/com/gpudb/GPUdbLogger.java
@@ -1,161 +1,54 @@
 package com.gpudb;
 
-import org.apache.log4j.Appender;
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.ConsoleAppender;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
-import java.util.Enumeration;
-
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GPUdbLogger {
 
-    // The default logging level--off
-    protected static final Level DEFAULT_LOGGING_LEVEL = Level.OFF;
-
     // The name of the logger for this API
-    protected static final String API_LOGGER_NAME = "Kinetica Java API";
+    protected static final String API_LOGGER_NAME = "com.gpudb";
 
-    // The loggers used for dependent libraries that might have obnxious
+    // The loggers used for dependent libraries that might have obnoxious
     // default log levels
     protected static final String DEP_LIB_APACHE_CLIENT_LOGGER = "org.apache.http";
 
-
     // Actual logger used for the API
-    private static Logger LOG = Logger.getLogger( API_LOGGER_NAME );
+    private static final Logger LOG = LoggerFactory.getLogger(API_LOGGER_NAME);
 
-
-    /**
-     * Initializes the logger with the given logging level.  It is
-     * **crucial** to call this method before using the logger.  This method
-     * serves the following purpose:
-     * * If no log4j.properties or any other properties file is found
-     *   in the class path of the application that uses this API, log4j
-     *   emits warnings about not finding any appender.  This method
-     *   prevents that from happening.
-     * * Older versions of the API did not have logging, so suddenly having
-     *   logging might throw off end user applications.  So, by default,
-     *   we turn off logging (controlled by the static final member above).
-     * * If no logging properties were provided by the end-user, then suppress
-     *   the obnoxious debug logging that is turned on by default by the Apache
-     *   HTTPClient library.
-     * * If the given log level is different from the default, set it explicitly.
-     */
-    public static void initializeLogger( Level loggingLevel ) {
-        Logger rootLogger = Logger.getRootLogger();
-
-        // Check for appenders--if none found, then that means the
-        // end-user application has not supplied any logging properties
-        // (which indicates that they probably don't expect any logging).
-        Enumeration<Appender> appenders = rootLogger.getAllAppenders();
-        boolean isLoggerConfiguredByUser = appenders.hasMoreElements();
-
-        if ( !isLoggerConfiguredByUser ) {
-            // No appender is found; suppress log4j warnings by explicitly
-            // getting the logger for the API
-            LOG = Logger.getLogger( API_LOGGER_NAME );
-
-            // Configuring log4j helps towards suppressing the annoying log4j
-            // warnings
-            PatternLayout layout = new PatternLayout( "%d{yyyy-MM-dd HH:mm:ss} %-5p  %m%n" );
-            ConsoleAppender consoleAppender = new ConsoleAppender();
-            consoleAppender.setLayout( layout );
-            consoleAppender.activateOptions();
-            BasicConfigurator.configure( consoleAppender );
-
-            // Set the API's log level
-            LOG.setLevel( loggingLevel );
-
-            // Set the Apache HTTPClient log leve as well
-            Logger.getLogger( "org.apache.http" ).setLevel( loggingLevel );
-        } else {
-            // If the log level is different from the default, set it explicitly
-            if ( !loggingLevel.equals( DEFAULT_LOGGING_LEVEL ) ) {
-                LOG.setLevel( loggingLevel );
-                LOG.warn( "Log properties set, but the log level is also "
-                          + "programmatically set by the user ('"
-                          + loggingLevel.toString()
-                          + "'); using that one and ignoring the one in "
-                          + "the properties.");
-            }
-
-            // Some logging properties found; check if the libraries that this
-            // API uses have log levels defined in the properties.  If not, we
-            // will turn them off (at least the obnoxious ones).  For that, first
-            // look for such loggers in the user given properties.
-            boolean isApacheHttpClientLoggerFound = false;
-            Enumeration<Logger> loggers = rootLogger.getHierarchy().getCurrentLoggers();
-            while ( loggers.hasMoreElements() ) {
-                if ( loggers.nextElement()
-                     .getName()
-                     .equalsIgnoreCase( DEP_LIB_APACHE_CLIENT_LOGGER ) ) {
-                    isApacheHttpClientLoggerFound = true;
-                }
-            }
-
-            // Mute the obnoxious logs if not set by the user
-            if ( !isApacheHttpClientLoggerFound ) {
-                Logger.getLogger( DEP_LIB_APACHE_CLIENT_LOGGER ).setLevel( Level.OFF );
-            }
-        }
-    }   // end initializeLogger
-
+    public static boolean isInfoEnabled() {
+        return LOG.isInfoEnabled();
+    }
 
     public static void info(String message) {
-        LOG.info( message );
+        LOG.info(message);
     }
 
     public static void error(String message) {
-        LOG.error( message );
+        LOG.error(message);
     }
 
     public static void warn(String message) {
-        LOG.warn( message );
+        LOG.warn(message);
     }
-
-    public static void fatal(String message) {
-        LOG.fatal( message );
-    }
-
 
     public static void debug(String message) {
-        LOG.debug( message );
+        LOG.debug(message);
     }
-
 
     public static void trace(String message) {
-        LOG.trace( message );
+        LOG.trace(message);
     }
-
 
     /**
      * Print extra information with the debug message.
      */
     public static void debug_with_info(String message) {
-        if ( ( LOG.getEffectiveLevel() == Level.DEBUG )
-             || ( LOG.getEffectiveLevel() == Level.TRACE )
-             || ( LOG.getEffectiveLevel() == Level.ALL ) ) {
-            // Getting the line number is expensive, so only do this
-            // if the appropriate log level is chosen
-            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-
+        if (LOG.isTraceEnabled() || LOG.isDebugEnabled()) {
             // We want the calling method and class name and the line number
-            StackTraceElement callingPoint = stackTrace[ 2 ];
-
-            // Build the message
-            StringBuilder builder = new StringBuilder();
-            builder.append( "[" );
-            builder.append( callingPoint.toString() );
-            builder.append( "] " );
-            builder.append( message );
-
-            // Finally, log the debug message
-            LOG.debug( builder.toString() );
+            StackTraceElement callingPoint = Thread.currentThread().getStackTrace()[2];
+            debug("[" + callingPoint + "] " + message);
         } else {
-            // Nothing fancy to calculate if the log level is not debug
-            LOG.debug( message );
+            debug(message);
         }
     }
 
@@ -164,27 +57,12 @@ public class GPUdbLogger {
      * Print extra information with the trace message.
      */
     public static void trace_with_info(String message) {
-        if ( ( LOG.getEffectiveLevel() == Level.TRACE )
-             || ( LOG.getEffectiveLevel() == Level.ALL ) ) {
-            // Getting the line number is expensive, so only do this
-            // if the appropriate log level is chosen
-            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-
+        if (LOG.isTraceEnabled()) {
             // We want the calling method and class name and the line number
-            StackTraceElement callingPoint = stackTrace[ 2 ];
-
-            // Build the message
-            StringBuilder builder = new StringBuilder();
-            builder.append( "[" );
-            builder.append( callingPoint.toString() );
-            builder.append( "] " );
-            builder.append( message );
-
-            // Finally, log the debug message
-            LOG.trace( builder.toString() );
+            StackTraceElement callingPoint = Thread.currentThread().getStackTrace()[2];
+            trace("[" + callingPoint + "] " + message);
         } else {
-            // Nothing fancy to calculate if the log level is not debug
-            LOG.trace( message );
+            trace(message);
         }
     }
 

--- a/api/src/test/java/com/gpudb/GPUdbLoggerTest.java
+++ b/api/src/test/java/com/gpudb/GPUdbLoggerTest.java
@@ -1,0 +1,48 @@
+package com.gpudb;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GPUdbLoggerTest {
+
+    private static final Path TEST_LOG_FILE_PATH = Paths.get("build/logs/gpudb-api.log");
+
+    @BeforeEach
+    public void beforeEach() {
+        try {
+            Files.deleteIfExists(TEST_LOG_FILE_PATH);
+        } catch (IOException e) {
+            System.out.printf("Could not delete %s due to %s%n", TEST_LOG_FILE_PATH, e);
+        }
+    }
+
+    @Test
+    public void testLogMessagesAreAppendedToLogFile() throws Exception {
+        GPUdbLogger.trace("Test log message");
+        GPUdbLogger.debug("Test log message");
+        GPUdbLogger.info("Test log message");
+        GPUdbLogger.warn("Test log message");
+        GPUdbLogger.error("Test log message");
+
+        // give some time for the logged messages to be flushed to the file
+        Thread.sleep(5000);
+        List<String> traceMessages = Files.lines(TEST_LOG_FILE_PATH)
+                .filter(line -> line.contains("TRACE"))
+                .collect(Collectors.<String>toList());
+        assertTrue(traceMessages.isEmpty());
+        List<String> nonTraceMessages = Files.lines(TEST_LOG_FILE_PATH)
+                .filter(line -> !line.contains("TRACE"))
+                .collect(Collectors.toList());
+        assertEquals(4, nonTraceMessages.size());
+    }
+
+}

--- a/api/src/test/resources/log4j2-test.xml
+++ b/api/src/test/resources/log4j2-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <File name="File" fileName="build/logs/gpudb-api.log">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+    <Loggers>
+        <Root level="ERROR">
+            <AppenderRef ref="File"/>
+        </Root>
+        <Logger name="com.gpudb" level="DEBUG" additivity="false">
+            <AppenderRef ref="File"/>
+        </Logger>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This is to start the discussion on replacing the legacy, insecure, and no longer maintained version of log4j:1.2.17 used by gpudb with slf4j. That would allow users to plug in the logging backend of their choice.